### PR TITLE
Add `name` parameter to the `__init__` of all op classes.

### DIFF
--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -12,9 +12,6 @@ from keras.src.utils import traceback_utils
 
 
 class Map(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, f, xs):
         return backend.core.map(f, xs)
 
@@ -78,8 +75,8 @@ def map(f, xs):
 
 
 class Scan(Operation):
-    def __init__(self, length=None, reverse=False, unroll=1):
-        super().__init__()
+    def __init__(self, length=None, reverse=False, unroll=1, *, name=None):
+        super().__init__(name=name)
         self.length = length
         self.reverse = reverse
         self.unroll = unroll
@@ -191,8 +188,8 @@ def scan(f, init, xs=None, length=None, reverse=False, unroll=1):
 
 
 class AssociativeScan(Operation):
-    def __init__(self, reverse=False, axis=0):
-        super().__init__()
+    def __init__(self, reverse=False, axis=0, *, name=None):
+        super().__init__(name=name)
         self.reverse = reverse
         self.axis = axis
 
@@ -289,8 +286,8 @@ def associative_scan(f, elems, reverse=False, axis=0):
 
 
 class Scatter(Operation):
-    def __init__(self, shape):
-        super().__init__()
+    def __init__(self, shape, *, name=None):
+        super().__init__(name=name)
         self.shape = shape
 
     def call(self, indices, values):
@@ -392,8 +389,8 @@ def scatter_update(inputs, indices, updates):
 
 
 class Slice(Operation):
-    def __init__(self, shape):
-        super().__init__()
+    def __init__(self, shape, *, name=None):
+        super().__init__(name=name)
         self.shape = shape
 
     def call(self, inputs, start_indices):
@@ -530,8 +527,8 @@ def switch(index, branches, *operands):
 
 
 class WhileLoop(Operation):
-    def __init__(self, cond, body, maximum_iterations=None):
-        super().__init__()
+    def __init__(self, cond, body, maximum_iterations=None, *, name=None):
+        super().__init__(name=name)
         self.cond = cond
         self.body = body
         self.maximum_iterations = maximum_iterations
@@ -599,9 +596,6 @@ def while_loop(
 
 
 class StopGradient(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, variable):
         return backend.core.stop_gradient(variable)
 
@@ -634,8 +628,8 @@ def stop_gradient(variable):
 
 
 class ForiLoop(Operation):
-    def __init__(self, lower, upper, body_fun):
-        super().__init__()
+    def __init__(self, lower, upper, body_fun, *, name=None):
+        super().__init__(name=name)
         self.lower = lower
         self.upper = upper
         self.body_fun = body_fun
@@ -682,8 +676,8 @@ def fori_loop(lower, upper, body_fun, init_val):
 
 
 class Unstack(Operation):
-    def __init__(self, num=None, axis=0):
-        super().__init__()
+    def __init__(self, num=None, axis=0, *, name=None):
+        super().__init__(name=name)
         self.num = num
         self.axis = axis
 
@@ -787,8 +781,8 @@ def dtype(x):
 
 
 class Cast(Operation):
-    def __init__(self, dtype):
-        super().__init__()
+    def __init__(self, dtype, *, name=None):
+        super().__init__(name=name)
         self.dtype = backend.standardize_dtype(dtype)
 
     def call(self, x):
@@ -822,8 +816,8 @@ def cast(x, dtype):
 
 
 class SaturateCast(Operation):
-    def __init__(self, dtype):
-        super().__init__()
+    def __init__(self, dtype, *, name=None):
+        super().__init__(name=name)
         self.dtype = backend.standardize_dtype(dtype)
 
     def call(self, x):
@@ -928,8 +922,8 @@ def _saturate_cast(x, dtype, backend_module=None):
 
 
 class ConvertToTensor(Operation):
-    def __init__(self, dtype=None, sparse=None, ragged=None):
-        super().__init__()
+    def __init__(self, dtype=None, sparse=None, ragged=None, *, name=None):
+        super().__init__(name=name)
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
         self.sparse = sparse
         self.ragged = ragged

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -8,8 +8,8 @@ from keras.src.ops.operation_utils import compute_conv_output_shape
 
 
 class RGBToGrayscale(Operation):
-    def __init__(self, data_format=None):
-        super().__init__()
+    def __init__(self, data_format=None, *, name=None):
+        super().__init__(name=name)
         self.data_format = backend.standardize_data_format(data_format)
 
     def call(self, images):
@@ -77,8 +77,8 @@ def rgb_to_grayscale(images, data_format=None):
 
 
 class RGBToHSV(Operation):
-    def __init__(self, data_format=None):
-        super().__init__()
+    def __init__(self, data_format=None, *, name=None):
+        super().__init__(name=name)
         self.data_format = backend.standardize_data_format(data_format)
 
     def call(self, images):
@@ -149,8 +149,8 @@ def rgb_to_hsv(images, data_format=None):
 
 
 class HSVToRGB(Operation):
-    def __init__(self, data_format=None):
-        super().__init__()
+    def __init__(self, data_format=None, *, name=None):
+        super().__init__(name=name)
         self.data_format = backend.standardize_data_format(data_format)
 
     def call(self, images):
@@ -228,8 +228,10 @@ class Resize(Operation):
         fill_mode="constant",
         fill_value=0.0,
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.size = tuple(size)
         self.interpolation = interpolation
         self.antialias = antialias
@@ -413,8 +415,10 @@ class AffineTransform(Operation):
         fill_mode="constant",
         fill_value=0,
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.interpolation = interpolation
         self.fill_mode = fill_mode
         self.fill_value = fill_value
@@ -554,8 +558,10 @@ class ExtractPatches(Operation):
         dilation_rate=1,
         padding="valid",
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         if isinstance(size, int):
             size = (size, size)
         self.size = size
@@ -707,8 +713,8 @@ def _extract_patches(
 
 
 class MapCoordinates(Operation):
-    def __init__(self, order, fill_mode="constant", fill_value=0):
-        super().__init__()
+    def __init__(self, order, fill_mode="constant", fill_value=0, *, name=None):
+        super().__init__(name=name)
         self.order = order
         self.fill_mode = fill_mode
         self.fill_value = fill_value
@@ -803,8 +809,10 @@ class PadImages(Operation):
         target_height=None,
         target_width=None,
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.top_padding = top_padding
         self.left_padding = left_padding
         self.bottom_padding = bottom_padding
@@ -1014,8 +1022,10 @@ class CropImages(Operation):
         target_height=None,
         target_width=None,
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.top_cropping = top_cropping
         self.bottom_cropping = bottom_cropping
         self.left_cropping = left_cropping
@@ -1238,8 +1248,10 @@ class PerspectiveTransform(Operation):
         interpolation="bilinear",
         fill_value=0,
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.interpolation = interpolation
         self.fill_value = fill_value
         self.data_format = backend.standardize_data_format(data_format)
@@ -1381,8 +1393,10 @@ class GaussianBlur(Operation):
         kernel_size=(3, 3),
         sigma=(1.0, 1.0),
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.kernel_size = kernel_size
         self.sigma = sigma
         self.data_format = backend.standardize_data_format(data_format)
@@ -1470,8 +1484,10 @@ class ElasticTransform(Operation):
         fill_value=0.0,
         seed=None,
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.alpha = alpha
         self.sigma = sigma
         self.interpolation = interpolation

--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -7,9 +7,6 @@ from keras.src.ops.operation_utils import reduce_shape
 
 
 class Cholesky(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return _cholesky(x)
 
@@ -47,9 +44,6 @@ def _cholesky(x):
 
 
 class Det(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return _det(x)
 
@@ -83,9 +77,6 @@ def _det(x):
 
 
 class Eig(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return _eig(x)
 
@@ -122,9 +113,6 @@ def _eig(x):
 
 
 class Eigh(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return _eigh(x)
 
@@ -162,9 +150,6 @@ def _eigh(x):
 
 
 class Inv(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return _inv(x)
 
@@ -198,9 +183,6 @@ def _inv(x):
 
 
 class LuFactor(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return _lu_factor(x)
 
@@ -248,8 +230,8 @@ def _lu_factor(x):
 
 
 class Norm(Operation):
-    def __init__(self, ord=None, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, ord=None, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(ord, str):
             if ord not in ("fro", "nuc"):
                 raise ValueError(
@@ -367,8 +349,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
 
 class Qr(Operation):
-    def __init__(self, mode="reduced"):
-        super().__init__()
+    def __init__(self, mode="reduced", *, name=None):
+        super().__init__(name=name)
         if mode not in {"reduced", "complete"}:
             raise ValueError(
                 "`mode` argument value not supported. "
@@ -440,9 +422,6 @@ def qr(x, mode="reduced"):
 
 
 class Solve(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, a, b):
         return _solve(a, b)
 
@@ -484,8 +463,8 @@ def _solve(a, b):
 
 
 class SolveTriangular(Operation):
-    def __init__(self, lower=False):
-        super().__init__()
+    def __init__(self, lower=False, *, name=None):
+        super().__init__(name=name)
         self.lower = lower
 
     def call(self, a, b):
@@ -531,8 +510,8 @@ def _solve_triangular(a, b, lower=False):
 
 
 class SVD(Operation):
-    def __init__(self, full_matrices=True, compute_uv=True):
-        super().__init__()
+    def __init__(self, full_matrices=True, compute_uv=True, *, name=None):
+        super().__init__(name=name)
         self.full_matrices = full_matrices
         self.compute_uv = compute_uv
 
@@ -586,8 +565,8 @@ def _svd(x, full_matrices=True, compute_uv=True):
 
 
 class Lstsq(Operation):
-    def __init__(self, rcond=None):
-        super().__init__()
+    def __init__(self, rcond=None, *, name=None):
+        super().__init__(name=name)
         self.rcond = rcond
 
     def call(self, a, b):

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -32,8 +32,8 @@ def _segment_reduce_validation(data, segment_ids):
 
 
 class SegmentReduction(Operation):
-    def __init__(self, num_segments=None, sorted=False):
-        super().__init__()
+    def __init__(self, num_segments=None, sorted=False, *, name=None):
+        super().__init__(name=name)
         self.num_segments = num_segments
         self.sorted = sorted
 
@@ -134,8 +134,8 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
 
 
 class TopK(Operation):
-    def __init__(self, k, sorted=True):
-        super().__init__()
+    def __init__(self, k, sorted=True, *, name=None):
+        super().__init__(name=name)
         self.k = k
         self.sorted = sorted
 
@@ -183,8 +183,8 @@ def top_k(x, k, sorted=True):
 
 
 class InTopK(Operation):
-    def __init__(self, k):
-        super().__init__()
+    def __init__(self, k, *, name=None):
+        super().__init__(name=name)
         self.k = k
 
     def compute_output_spec(self, targets, predictions):
@@ -223,8 +223,8 @@ def in_top_k(targets, predictions, k):
 
 
 class Logsumexp(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.keepdims = keepdims
 
@@ -264,8 +264,8 @@ def logsumexp(x, axis=None, keepdims=False):
 
 
 class ExtractSequences(Operation):
-    def __init__(self, sequence_length, sequence_stride):
-        super().__init__()
+    def __init__(self, sequence_length, sequence_stride, *, name=None):
+        super().__init__(name=name)
         self.sequence_length = sequence_length
         self.sequence_stride = sequence_stride
 
@@ -396,11 +396,8 @@ def fft(x):
 
 
 class FFT2(Operation):
-    def __init__(self):
-        super().__init__()
-        self.axes = (-2, -1)
-
     def compute_output_spec(self, x):
+        axes = (-2, -1)
         if not isinstance(x, (tuple, list)) or len(x) != 2:
             raise ValueError(
                 "Input `x` should be a tuple of two tensors - real and "
@@ -424,11 +421,11 @@ class FFT2(Operation):
             )
 
         # The axes along which we are calculating FFT should be fully-defined.
-        m = real.shape[self.axes[0]]
-        n = real.shape[self.axes[1]]
+        m = real.shape[axes[0]]
+        n = real.shape[axes[1]]
         if m is None or n is None:
             raise ValueError(
-                f"Input should have its {self.axes} axes fully-defined. "
+                f"Input should have its {axes} axes fully-defined. "
                 f"Received: input.shape = {real.shape}"
             )
 
@@ -470,11 +467,8 @@ def fft2(x):
 
 
 class IFFT2(Operation):
-    def __init__(self):
-        super().__init__()
-        self.axes = (-2, -1)
-
     def compute_output_spec(self, x):
+        axes = (-2, -1)
         if not isinstance(x, (tuple, list)) or len(x) != 2:
             raise ValueError(
                 "Input `x` should be a tuple of two tensors - real and "
@@ -498,11 +492,11 @@ class IFFT2(Operation):
             )
 
         # The axes along which we are calculating IFFT should be fully-defined.
-        m = real.shape[self.axes[0]]
-        n = real.shape[self.axes[1]]
+        m = real.shape[axes[0]]
+        n = real.shape[axes[1]]
         if m is None or n is None:
             raise ValueError(
-                f"Input should have its {self.axes} axes fully-defined. "
+                f"Input should have its {axes} axes fully-defined. "
                 f"Received: input.shape = {real.shape}"
             )
 
@@ -545,8 +539,8 @@ def ifft2(x):
 
 
 class RFFT(Operation):
-    def __init__(self, fft_length=None):
-        super().__init__()
+    def __init__(self, fft_length=None, *, name=None):
+        super().__init__(name=name)
         self.fft_length = fft_length
 
     def compute_output_spec(self, x):
@@ -616,8 +610,8 @@ def rfft(x, fft_length=None):
 
 
 class IRFFT(Operation):
-    def __init__(self, fft_length=None):
-        super().__init__()
+    def __init__(self, fft_length=None, *, name=None):
+        super().__init__(name=name)
         self.fft_length = fft_length
 
     def compute_output_spec(self, x):
@@ -708,8 +702,10 @@ class STFT(Operation):
         fft_length,
         window="hann",
         center=True,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.sequence_length = sequence_length
         self.sequence_stride = sequence_stride
         self.fft_length = fft_length
@@ -809,8 +805,10 @@ class ISTFT(Operation):
         length=None,
         window="hann",
         center=True,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.sequence_length = sequence_length
         self.sequence_stride = sequence_stride
         self.fft_length = fft_length
@@ -1017,9 +1015,6 @@ def erfinv(x):
 
 
 class Logdet(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.math.logdet(x)
 

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -213,8 +213,8 @@ def softsign(x):
 
 
 class SoftShrink(Operation):
-    def __init__(self, threshold=0.5):
-        super().__init__()
+    def __init__(self, threshold=0.5, *, name=None):
+        super().__init__(name=name)
         self.threshold = threshold
 
     def call(self, x):
@@ -335,8 +335,8 @@ def silu(x):
 
 
 class Squareplus(Operation):
-    def __init__(self, b=4):
-        super().__init__()
+    def __init__(self, b=4, *, name=None):
+        super().__init__(name=name)
         self.b = b
 
     def call(self, x):
@@ -412,8 +412,8 @@ def log_sigmoid(x):
 
 
 class LeakyRelu(Operation):
-    def __init__(self, negative_slope=0.2):
-        super().__init__()
+    def __init__(self, negative_slope=0.2, *, name=None):
+        super().__init__(name=name)
         self.negative_slope = negative_slope
 
     def call(self, x):
@@ -538,8 +538,8 @@ def hard_silu(x):
 
 
 class Elu(Operation):
-    def __init__(self, alpha=1.0):
-        super().__init__()
+    def __init__(self, alpha=1.0, *, name=None):
+        super().__init__(name=name)
         self.alpha = alpha
 
     def call(self, x):
@@ -614,8 +614,8 @@ def selu(x):
 
 
 class Gelu(Operation):
-    def __init__(self, approximate=True):
-        super().__init__()
+    def __init__(self, approximate=True, *, name=None):
+        super().__init__(name=name)
         self.approximate = approximate
 
     def call(self, x):
@@ -657,8 +657,8 @@ def gelu(x, approximate=True):
 
 
 class Celu(Operation):
-    def __init__(self, alpha=1.0):
-        super().__init__()
+    def __init__(self, alpha=1.0, *, name=None):
+        super().__init__(name=name)
         self.alpha = alpha
 
     def call(self, x):
@@ -697,8 +697,8 @@ def celu(x, alpha=1.0):
 
 
 class Glu(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
+    def __init__(self, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -738,9 +738,6 @@ def glu(x, axis=-1):
 
 
 class TanhShrink(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.nn.tanh_shrink(x)
 
@@ -777,9 +774,6 @@ def tanh_shrink(x):
 
 
 class HardTanh(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.nn.hard_tanh(x)
 
@@ -816,8 +810,8 @@ def hard_tanh(x):
 
 
 class HardShrink(Operation):
-    def __init__(self, threshold=0.5):
-        super().__init__()
+    def __init__(self, threshold=0.5, *, name=None):
+        super().__init__(name=name)
         self.threshold = threshold
 
     def call(self, x):
@@ -857,8 +851,8 @@ def hard_shrink(x, threshold=0.5):
 
 
 class Threshold(Operation):
-    def __init__(self, threshold, default_value):
-        super().__init__()
+    def __init__(self, threshold, default_value, *, name=None):
+        super().__init__(name=name)
         self.threshold = threshold
         self.default_value = default_value
 
@@ -899,8 +893,8 @@ def threshold(x, threshold, default_value):
 
 
 class Softmax(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
+    def __init__(self, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -971,8 +965,8 @@ def softmax(x, axis=-1):
 
 
 class LogSoftmax(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
+    def __init__(self, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -1032,8 +1026,8 @@ def log_softmax(x, axis=-1):
 
 
 class Sparsemax(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
+    def __init__(self, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -1080,8 +1074,10 @@ class MaxPool(Operation):
         strides=None,
         padding="valid",
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.pool_size = pool_size
         self.strides = strides
         self.padding = padding.lower()
@@ -1166,8 +1162,10 @@ class AveragePool(Operation):
         strides=None,
         padding="valid",
         data_format=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.pool_size = pool_size
         self.strides = strides
         self.padding = padding.lower()
@@ -1259,8 +1257,10 @@ class Conv(Operation):
         padding="valid",
         data_format=None,
         dilation_rate=1,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.strides = strides
         self.padding = padding.lower()
         self.data_format = data_format
@@ -1352,8 +1352,10 @@ class DepthwiseConv(Operation):
         padding="valid",
         data_format=None,
         dilation_rate=1,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.strides = strides
         self.padding = padding.lower()
         self.data_format = data_format
@@ -1455,8 +1457,10 @@ class SeparableConv(Operation):
         padding="valid",
         data_format=None,
         dilation_rate=1,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.strides = strides
         self.padding = padding.lower()
         self.data_format = data_format
@@ -1574,8 +1578,10 @@ class ConvTranspose(Operation):
         output_padding=None,
         data_format=None,
         dilation_rate=1,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.strides = strides
         self.output_padding = output_padding
         self.padding = padding.lower()
@@ -1689,8 +1695,10 @@ def conv_transpose(
 
 
 class OneHot(Operation):
-    def __init__(self, num_classes, axis=-1, dtype=None, sparse=False):
-        super().__init__()
+    def __init__(
+        self, num_classes, axis=-1, dtype=None, sparse=False, *, name=None
+    ):
+        super().__init__(name=name)
         self.num_classes = num_classes
         self.axis = axis
         self.dtype = backend.standardize_dtype(dtype)
@@ -1768,8 +1776,8 @@ def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
 
 
 class BinaryCrossentropy(Operation):
-    def __init__(self, from_logits=False):
-        super().__init__()
+    def __init__(self, from_logits=False, *, name=None):
+        super().__init__(name=name)
         self.from_logits = from_logits
 
     def call(self, target, output):
@@ -1835,8 +1843,8 @@ def binary_crossentropy(target, output, from_logits=False):
 
 
 class CategoricalCrossentropy(Operation):
-    def __init__(self, from_logits=False, axis=-1):
-        super().__init__()
+    def __init__(self, from_logits=False, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.from_logits = from_logits
         self.axis = axis
 
@@ -1919,8 +1927,8 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
 
 
 class SparseCategoricalCrossentropy(Operation):
-    def __init__(self, from_logits=False, axis=-1):
-        super().__init__()
+    def __init__(self, from_logits=False, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.from_logits = from_logits
         self.axis = axis
 
@@ -2005,13 +2013,20 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
 
 class MultiHot(Operation):
     def __init__(
-        self, num_classes=None, axis=-1, dtype=None, sparse=False, **kwargs
+        self,
+        num_classes=None,
+        axis=-1,
+        dtype=None,
+        sparse=False,
+        *,
+        name=None,
+        **kwargs,
     ):
         if num_classes is None and "num_tokens" in kwargs:
             num_classes = kwargs.pop("num_tokens")
         if num_classes is None:
             raise ValueError("Argument `num_classes` must be specified.")
-        super().__init__(**kwargs)
+        super().__init__(name=name)
         self.num_classes = num_classes
         self.axis = axis
         self.dtype = dtype or backend.floatx()
@@ -2091,8 +2106,8 @@ def multi_hot(
 
 
 class Moments(Operation):
-    def __init__(self, axes, keepdims=False, synchronized=False):
-        super().__init__()
+    def __init__(self, axes, keepdims=False, synchronized=False, *, name=None):
+        super().__init__(name=name)
         self.axes = axes
         self.keepdims = keepdims
         self.synchronized = synchronized
@@ -2161,8 +2176,8 @@ def moments(x, axes, keepdims=False, synchronized=False):
 
 
 class BatchNorm(Operation):
-    def __init__(self, axis, epsilon=1e-3):
-        super().__init__()
+    def __init__(self, axis, epsilon=1e-3, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.epsilon = epsilon
 
@@ -2256,8 +2271,8 @@ def batch_normalization(
 
 
 class CTCLoss(Operation):
-    def __init__(self, mask_index=0):
-        super().__init__()
+    def __init__(self, mask_index=0, *, name=None):
+        super().__init__(name=name)
         self.mask_index = mask_index
 
     def call(self, target, output, target_length, output_length):
@@ -2326,8 +2341,10 @@ class CTCDecode(Operation):
         top_paths=1,
         merge_repeated=True,
         mask_index=0,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.strategy = strategy
         self.beam_width = beam_width
         self.top_paths = top_paths
@@ -2428,8 +2445,8 @@ def ctc_decode(
 
 
 class Normalize(Operation):
-    def __init__(self, axis=-1, order=2, epsilon=None):
-        super().__init__()
+    def __init__(self, axis=-1, order=2, epsilon=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.order = order
         self.epsilon = epsilon
@@ -2510,8 +2527,10 @@ class PSNR(Operation):
     def __init__(
         self,
         max_val,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.max_val = max_val
 
     def call(self, x1, x2):
@@ -2581,9 +2600,14 @@ def psnr(
 
 class DotProductAttention(Operation):
     def __init__(
-        self, is_causal=False, flash_attention=None, attn_logits_soft_cap=None
+        self,
+        is_causal=False,
+        flash_attention=None,
+        attn_logits_soft_cap=None,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.is_causal = is_causal
         self.flash_attention = flash_attention
         self.attn_logits_soft_cap = attn_logits_soft_cap
@@ -2729,8 +2753,8 @@ def dot_product_attention(
 
 
 class RMSNorm(Operation):
-    def __init__(self, scale=1, axis=-1, epsilon=None):
-        super().__init__()
+    def __init__(self, scale=1, axis=-1, epsilon=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.scale = scale
         self.epsilon = epsilon
@@ -2814,9 +2838,16 @@ def _rms_normalization(x, scale=1, axis=-1, epsilon=None):
 
 class LayerNorm(Operation):
     def __init__(
-        self, gamma=None, beta=None, axis=-1, epsilon=None, rms_scaling=False
+        self,
+        gamma=None,
+        beta=None,
+        axis=-1,
+        epsilon=None,
+        rms_scaling=False,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.axis = axis
         self.gamma = gamma
         self.beta = beta
@@ -2949,9 +2980,6 @@ def _layer_normalization(
 
 
 class Polar(Operation):
-    def __init__(self):
-        super().__init__()
-
     def compute_output_spec(self, abs_, angle):
         return KerasTensor(shape=abs_.shape)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -17,8 +17,8 @@ from keras.src.ops.operation_utils import reduce_shape
 
 
 class Rot90(Operation):
-    def __init__(self, k=1, axes=(0, 1)):
-        super().__init__()
+    def __init__(self, k=1, axes=(0, 1), *, name=None):
+        super().__init__(name=name)
         self.k = k
         self.axes = axes
 
@@ -238,8 +238,8 @@ def add(x1, x2):
 
 
 class All(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = [axis]
         else:
@@ -302,8 +302,8 @@ def all(x, axis=None, keepdims=False):
 
 
 class Any(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = [axis]
         else:
@@ -401,8 +401,8 @@ def any(x, axis=None, keepdims=False):
 
 
 class Amax(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -460,8 +460,8 @@ def amax(x, axis=None, keepdims=False):
 
 
 class Amin(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -515,8 +515,8 @@ def amin(x, axis=None, keepdims=False):
 
 
 class Append(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x1, x2):
@@ -591,8 +591,8 @@ def append(
 
 
 class Arange(Operation):
-    def __init__(self, dtype=None):
-        super().__init__()
+    def __init__(self, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
     def call(self, start, stop=None, step=1):
@@ -930,8 +930,8 @@ def arctanh(x):
 
 
 class Argmax(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.keepdims = keepdims
 
@@ -981,8 +981,8 @@ def argmax(x, axis=None, keepdims=False):
 
 
 class Argmin(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.keepdims = keepdims
 
@@ -1032,8 +1032,8 @@ def argmin(x, axis=None, keepdims=False):
 
 
 class Argsort(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
+    def __init__(self, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -1084,8 +1084,8 @@ def argsort(x, axis=-1):
 
 
 class Array(Operation):
-    def __init__(self, dtype=None):
-        super().__init__()
+    def __init__(self, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
     def call(self, x):
@@ -1124,8 +1124,8 @@ def array(x, dtype=None):
 
 
 class Average(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         # np.average() does not support axis as tuple as declared by the
         # docstring, it only supports int or None.
         self.axis = axis
@@ -1318,8 +1318,8 @@ def hanning(x):
 
 
 class Kaiser(Operation):
-    def __init__(self, beta):
-        super().__init__()
+    def __init__(self, beta, *, name=None):
+        super().__init__(name=name)
         self.beta = beta
 
     def call(self, x):
@@ -1356,8 +1356,8 @@ def kaiser(x, beta):
 
 
 class Bincount(Operation):
-    def __init__(self, weights=None, minlength=0, sparse=False):
-        super().__init__()
+    def __init__(self, weights=None, minlength=0, sparse=False, *, name=None):
+        super().__init__(name=name)
         self.weights = weights
         self.minlength = minlength
         self.sparse = sparse
@@ -1434,9 +1434,6 @@ def bincount(x, weights=None, minlength=0, sparse=False):
 
 
 class BitwiseAnd(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.bitwise_and(x, y)
 
@@ -1466,9 +1463,6 @@ def bitwise_and(x, y):
 
 
 class BitwiseInvert(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.numpy.bitwise_invert(x)
 
@@ -1496,9 +1490,6 @@ def bitwise_invert(x):
 
 
 class BitwiseNot(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.numpy.bitwise_not(x)
 
@@ -1526,9 +1517,6 @@ def bitwise_not(x):
 
 
 class BitwiseOr(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.bitwise_or(x, y)
 
@@ -1558,9 +1546,6 @@ def bitwise_or(x, y):
 
 
 class BitwiseXor(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.bitwise_xor(x, y)
 
@@ -1590,9 +1575,6 @@ def bitwise_xor(x, y):
 
 
 class BitwiseLeftShift(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.bitwise_left_shift(x, y)
 
@@ -1627,9 +1609,6 @@ def bitwise_left_shift(x, y):
 
 
 class LeftShift(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.left_shift(x, y)
 
@@ -1662,9 +1641,6 @@ def left_shift(x, y):
 
 
 class BitwiseRightShift(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.bitwise_right_shift(x, y)
 
@@ -1699,9 +1675,6 @@ def bitwise_right_shift(x, y):
 
 
 class RightShift(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x, y):
         return backend.numpy.right_shift(x, y)
 
@@ -1764,8 +1737,8 @@ def blackman(x):
 
 
 class BroadcastTo(Operation):
-    def __init__(self, shape):
-        super().__init__()
+    def __init__(self, shape, *, name=None):
+        super().__init__(name=name)
         self.shape = shape
 
     def call(self, x):
@@ -1838,8 +1811,8 @@ def ceil(x):
 
 
 class Clip(Operation):
-    def __init__(self, x_min, x_max):
-        super().__init__()
+    def __init__(self, x_min, x_max, *, name=None):
+        super().__init__(name=name)
         self.x_min = x_min
         self.x_max = x_max
 
@@ -1874,8 +1847,8 @@ def clip(x, x_min, x_max):
 
 
 class Concatenate(Operation):
-    def __init__(self, axis=0):
-        super().__init__()
+    def __init__(self, axis=0, *, name=None):
+        super().__init__(name=name)
         if axis is None:
             raise ValueError("`axis` cannot be None for `concatenate`.")
         self.axis = axis
@@ -2051,8 +2024,8 @@ def cosh(x):
 
 
 class CountNonzero(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = (axis,)
         else:
@@ -2102,8 +2075,8 @@ def count_nonzero(x, axis=None):
 
 
 class Cross(Operation):
-    def __init__(self, axisa=-1, axisb=-1, axisc=-1, axis=None):
-        super().__init__()
+    def __init__(self, axisa=-1, axisb=-1, axisc=-1, axis=None, *, name=None):
+        super().__init__(name=name)
         if axis is not None:
             self.axisa = axis
             self.axisb = axis
@@ -2200,8 +2173,8 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 
 class Cumprod(Operation):
-    def __init__(self, axis=None, dtype=None):
-        super().__init__()
+    def __init__(self, axis=None, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
@@ -2243,8 +2216,8 @@ def cumprod(x, axis=None, dtype=None):
 
 
 class Cumsum(Operation):
-    def __init__(self, axis=None, dtype=None):
-        super().__init__()
+    def __init__(self, axis=None, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
@@ -2286,8 +2259,8 @@ def cumsum(x, axis=None, dtype=None):
 
 
 class Diag(Operation):
-    def __init__(self, k=0):
-        super().__init__()
+    def __init__(self, k=0, *, name=None):
+        super().__init__(name=name)
         self.k = k
 
     def call(self, x):
@@ -2362,8 +2335,8 @@ def diag(x, k=0):
 
 
 class Diagflat(Operation):
-    def __init__(self, k=0):
-        super().__init__()
+    def __init__(self, k=0, *, name=None):
+        super().__init__(name=name)
         self.k = k
 
     def call(self, x):
@@ -2418,8 +2391,8 @@ def diagflat(x, k=0):
 
 
 class Diagonal(Operation):
-    def __init__(self, offset=0, axis1=0, axis2=1):
-        super().__init__()
+    def __init__(self, offset=0, axis1=0, axis2=1, *, name=None):
+        super().__init__(name=name)
         self.offset = offset
         self.axis1 = axis1
         self.axis2 = axis2
@@ -2522,8 +2495,8 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 
 
 class Diff(Operation):
-    def __init__(self, n=1, axis=-1):
-        super().__init__()
+    def __init__(self, n=1, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.n = n
         self.axis = axis
 
@@ -2681,8 +2654,8 @@ def dot(x1, x2):
 
 
 class Einsum(Operation):
-    def __init__(self, subscripts):
-        super().__init__()
+    def __init__(self, subscripts, *, name=None):
+        super().__init__(name=name)
         self.subscripts = subscripts
 
     def call(self, *operands, **kwargs):
@@ -3042,8 +3015,8 @@ def exp2(x):
 
 
 class ExpandDims(Operation):
-    def __init__(self, axis):
-        super().__init__()
+    def __init__(self, axis, *, name=None):
+        super().__init__(name=name)
         if not isinstance(axis, (int, tuple, list)):
             raise ValueError(
                 "The `axis` argument to `expand_dims` should be an integer, "
@@ -3114,8 +3087,8 @@ def expm1(x):
 
 
 class Flip(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -3176,8 +3149,8 @@ def floor(x):
 
 
 class Full(Operation):
-    def __init__(self, shape, dtype=None):
-        super().__init__()
+    def __init__(self, shape, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.shape = shape
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
@@ -3207,8 +3180,8 @@ def full(shape, fill_value, dtype=None):
 
 
 class FullLike(Operation):
-    def __init__(self, dtype=None):
-        super().__init__()
+    def __init__(self, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
     def call(self, x, fill_value):
@@ -3467,8 +3440,8 @@ def imag(x):
 
 
 class Isclose(Operation):
-    def __init__(self, equal_nan=False):
-        super().__init__()
+    def __init__(self, equal_nan=False, *, name=None):
+        super().__init__(name=name)
         self.equal_nan = equal_nan
 
     def call(self, x1, x2, rtol=1e-5, atol=1e-8):
@@ -3634,9 +3607,16 @@ def less_equal(x1, x2):
 
 class Linspace(Operation):
     def __init__(
-        self, num=50, endpoint=True, retstep=False, dtype=None, axis=0
+        self,
+        num=50,
+        endpoint=True,
+        retstep=False,
+        dtype=None,
+        axis=0,
+        *,
+        name=None,
     ):
-        super().__init__()
+        super().__init__(name=name)
         self.num = num
         self.endpoint = endpoint
         self.retstep = retstep
@@ -3980,8 +3960,10 @@ def logical_or(x1, x2):
 
 
 class Logspace(Operation):
-    def __init__(self, num=50, endpoint=True, base=10, dtype=None, axis=0):
-        super().__init__()
+    def __init__(
+        self, num=50, endpoint=True, base=10, dtype=None, axis=0, *, name=None
+    ):
+        super().__init__(name=name)
         self.num = num
         self.endpoint = endpoint
         self.base = base
@@ -4114,8 +4096,8 @@ def matmul(x1, x2):
 
 
 class Max(Operation):
-    def __init__(self, axis=None, keepdims=False, initial=None):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, initial=None, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = [axis]
         else:
@@ -4194,8 +4176,8 @@ def maximum(x1, x2):
 
 
 class Median(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -4236,8 +4218,8 @@ def median(x, axis=None, keepdims=False):
 
 
 class Meshgrid(Operation):
-    def __init__(self, indexing="xy"):
-        super().__init__()
+    def __init__(self, indexing="xy", *, name=None):
+        super().__init__(name=name)
         if indexing not in ("xy", "ij"):
             raise ValueError(
                 "Valid values for `indexing` are 'xy' and 'ij', "
@@ -4307,8 +4289,8 @@ def meshgrid(*x, indexing="xy"):
 
 
 class Min(Operation):
-    def __init__(self, axis=None, keepdims=False, initial=None):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, initial=None, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = [axis]
         else:
@@ -4420,8 +4402,8 @@ def mod(x1, x2):
 
 
 class Moveaxis(Operation):
-    def __init__(self, source, destination):
-        super().__init__()
+    def __init__(self, source, destination, *, name=None):
+        super().__init__(name=name)
         if isinstance(source, int):
             self.source = [source]
         else:
@@ -4484,8 +4466,8 @@ def moveaxis(x, source, destination):
 
 
 class NanToNum(Operation):
-    def __init__(self, nan=0.0, posinf=None, neginf=None):
-        super().__init__()
+    def __init__(self, nan=0.0, posinf=None, neginf=None, *, name=None):
+        super().__init__(name=name)
         self.nan = nan
         self.posinf = posinf
         self.neginf = neginf
@@ -4602,8 +4584,8 @@ def not_equal(x1, x2):
 
 
 class OnesLike(Operation):
-    def __init__(self, dtype=None):
-        super().__init__()
+    def __init__(self, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
     def call(self, x):
@@ -4636,8 +4618,8 @@ def ones_like(x, dtype=None):
 
 
 class ZerosLike(Operation):
-    def __init__(self, dtype=None):
-        super().__init__()
+    def __init__(self, dtype=None, *, name=None):
+        super().__init__(name=name)
         self.dtype = None if dtype is None else backend.standardize_dtype(dtype)
 
     def call(self, x):
@@ -4720,8 +4702,8 @@ def outer(x1, x2):
 
 
 class Pad(Operation):
-    def __init__(self, pad_width, mode="constant"):
-        super().__init__()
+    def __init__(self, pad_width, mode="constant", *, name=None):
+        super().__init__(name=name)
         self.pad_width = self._process_pad_width(pad_width)
         self.mode = mode
 
@@ -4817,8 +4799,8 @@ def pad(x, pad_width, mode="constant", constant_values=None):
 
 
 class Prod(Operation):
-    def __init__(self, axis=None, keepdims=False, dtype=None):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, dtype=None, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = [axis]
         else:
@@ -4876,8 +4858,10 @@ def prod(x, axis=None, keepdims=False, dtype=None):
 
 
 class Quantile(Operation):
-    def __init__(self, axis=None, method="linear", keepdims=False):
-        super().__init__()
+    def __init__(
+        self, axis=None, method="linear", keepdims=False, *, name=None
+    ):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -4974,9 +4958,9 @@ def ravel(x):
 
 
 class UnravelIndex(Operation):
-    def __init__(self, shape):
+    def __init__(self, shape, *, name=None):
+        super().__init__(name=name)
         self.shape = shape
-        self._inbound_nodes = []
 
     def call(self, indices):
         return backend.numpy.unravel_index(indices, self.shape)
@@ -5079,8 +5063,8 @@ def reciprocal(x):
 
 
 class Repeat(Operation):
-    def __init__(self, repeats, axis=None):
-        super().__init__()
+    def __init__(self, repeats, axis=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
         self.repeats = repeats
 
@@ -5149,8 +5133,8 @@ def repeat(x, repeats, axis=None):
 
 
 class Reshape(Operation):
-    def __init__(self, newshape):
-        super().__init__()
+    def __init__(self, newshape, *, name=None):
+        super().__init__(name=name)
         self.newshape = newshape
 
     def call(self, x):
@@ -5183,8 +5167,8 @@ def reshape(x, newshape):
 
 
 class Roll(Operation):
-    def __init__(self, shift, axis=None):
-        super().__init__()
+    def __init__(self, shift, axis=None, *, name=None):
+        super().__init__(name=name)
         self.shift = shift
         self.axis = axis
 
@@ -5217,8 +5201,8 @@ def roll(x, shift, axis=None):
 
 
 class Round(Operation):
-    def __init__(self, decimals=0):
-        super().__init__()
+    def __init__(self, decimals=0, *, name=None):
+        super().__init__(name=name)
         self.decimals = decimals
 
     def call(self, x):
@@ -5246,8 +5230,8 @@ def round(x, decimals=0):
 
 
 class SearchSorted(Operation):
-    def __init__(self, side="left"):
-        super().__init__()
+    def __init__(self, side="left", *, name=None):
+        super().__init__(name=name)
         self.side = side
 
     def call(self, sorted_sequence, values):
@@ -5427,8 +5411,8 @@ def size(x):
 
 
 class Sort(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
+    def __init__(self, axis=-1, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -5456,8 +5440,8 @@ def sort(x, axis=-1):
 
 
 class Split(Operation):
-    def __init__(self, indices_or_sections, axis=0):
-        super().__init__()
+    def __init__(self, indices_or_sections, axis=0, *, name=None):
+        super().__init__(name=name)
         if not isinstance(indices_or_sections, int):
             indices_or_sections = tuple(indices_or_sections)
         self.indices_or_sections = indices_or_sections
@@ -5525,8 +5509,8 @@ def split(x, indices_or_sections, axis=0):
 
 
 class Stack(Operation):
-    def __init__(self, axis=0):
-        super().__init__()
+    def __init__(self, axis=0, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -5576,8 +5560,8 @@ def stack(x, axis=0):
 
 
 class Std(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             self.axis = [axis]
         else:
@@ -5618,8 +5602,8 @@ def std(x, axis=None, keepdims=False):
 
 
 class Swapaxes(Operation):
-    def __init__(self, axis1, axis2):
-        super().__init__()
+    def __init__(self, axis1, axis2, *, name=None):
+        super().__init__(name=name)
 
         self.axis1 = axis1
         self.axis2 = axis2
@@ -5653,8 +5637,8 @@ def swapaxes(x, axis1, axis2):
 
 
 class Take(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x, indices):
@@ -5696,8 +5680,8 @@ def take(x, indices, axis=None):
 
 
 class TakeAlongAxis(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x, indices):
@@ -5792,8 +5776,8 @@ def tanh(x):
 
 
 class Tensordot(Operation):
-    def __init__(self, axes=2):
-        super().__init__()
+    def __init__(self, axes=2, *, name=None):
+        super().__init__(name=name)
         self.axes = axes
 
     def call(self, x1, x2):
@@ -5859,8 +5843,8 @@ def tensordot(x1, x2, axes=2):
 
 
 class Tile(Operation):
-    def __init__(self, repeats):
-        super().__init__()
+    def __init__(self, repeats, *, name=None):
+        super().__init__(name=name)
         self.repeats = repeats
 
     def call(self, x):
@@ -5912,8 +5896,8 @@ def tile(x, repeats):
 
 
 class Trace(Operation):
-    def __init__(self, offset=0, axis1=0, axis2=1):
-        super().__init__()
+    def __init__(self, offset=0, axis1=0, axis2=1, *, name=None):
+        super().__init__(name=name)
         self.offset = offset
         self.axis1 = axis1
         self.axis2 = axis2
@@ -5987,8 +5971,8 @@ def tri(N, M=None, k=0, dtype=None):
 
 
 class Tril(Operation):
-    def __init__(self, k=0):
-        super().__init__()
+    def __init__(self, k=0, *, name=None):
+        super().__init__(name=name)
         self.k = k
 
     def call(self, x):
@@ -6019,8 +6003,8 @@ def tril(x, k=0):
 
 
 class Triu(Operation):
-    def __init__(self, k=0):
-        super().__init__()
+    def __init__(self, k=0, *, name=None):
+        super().__init__(name=name)
         self.k = k
 
     def call(self, x):
@@ -6051,9 +6035,6 @@ def triu(x, k=0):
 
 
 class Trunc(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.numpy.trunc(x)
 
@@ -6573,8 +6554,8 @@ def sqrt(x):
 
 
 class Squeeze(Operation):
-    def __init__(self, axis=None):
-        super().__init__()
+    def __init__(self, axis=None, *, name=None):
+        super().__init__(name=name)
         self.axis = axis
 
     def call(self, x):
@@ -6618,8 +6599,8 @@ def squeeze(x, axis=None):
 
 
 class Transpose(Operation):
-    def __init__(self, axes=None):
-        super().__init__()
+    def __init__(self, axes=None, *, name=None):
+        super().__init__(name=name)
         self.axes = axes
 
     def call(self, x):
@@ -6651,8 +6632,8 @@ def transpose(x, axes=None):
 
 
 class Mean(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -6696,8 +6677,8 @@ def mean(x, axis=None, keepdims=False):
 
 
 class Var(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -6734,8 +6715,8 @@ def var(x, axis=None, keepdims=False):
 
 
 class Sum(Operation):
-    def __init__(self, axis=None, keepdims=False):
-        super().__init__()
+    def __init__(self, axis=None, keepdims=False, *, name=None):
+        super().__init__(name=name)
         if isinstance(axis, int):
             axis = [axis]
         self.axis = axis
@@ -6886,8 +6867,8 @@ def logical_xor(x1, x2):
 
 
 class Correlate(Operation):
-    def __init__(self, mode="valid"):
-        super().__init__()
+    def __init__(self, mode="valid", *, name=None):
+        super().__init__(name=name)
         self.mode = mode
 
     def call(self, x1, x2):
@@ -6953,9 +6934,6 @@ def correlate(x1, x2, mode="valid"):
 
 
 class Select(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, condlist, choicelist, default=0):
         return backend.numpy.select(condlist, choicelist, default)
 
@@ -7020,9 +6998,6 @@ def select(condlist, choicelist, default=0):
 
 
 class Slogdet(Operation):
-    def __init__(self):
-        super().__init__()
-
     def call(self, x):
         return backend.numpy.slogdet(x)
 
@@ -7052,8 +7027,8 @@ def slogdet(x):
 
 
 class Argpartition(Operation):
-    def __init__(self, kth, axis=-1):
-        super().__init__()
+    def __init__(self, kth, axis=-1, *, name=None):
+        super().__init__(name=name)
         if not isinstance(kth, int):
             raise ValueError(f"kth must be an integer. Received:kth = {kth}")
         self.kth = kth
@@ -7094,8 +7069,8 @@ def argpartition(x, kth, axis=-1):
 
 
 class Histogram(Operation):
-    def __init__(self, bins=10, range=None):
-        super().__init__()
+    def __init__(self, bins=10, range=None, *, name=None):
+        super().__init__(name=name)
 
         if not isinstance(bins, int):
             raise TypeError("bins must be of type `int`")


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/21376

Follow up of https://github.com/keras-team/keras/pull/21373

This is to solve an inconsistency in the saving / reloading of ops. Some ops behave differently.

Consider this code:

```python
input = keras.layers.Input(shape=(4,), dtype="float32")
output = keras.ops.abs(input)
model = keras.models.Model(input, output)

json = model.to_json()
reloaded_model = keras.models.model_from_json(json)
reloaded_json = reloaded_model.to_json()
```

The reloaded model JSON is the same as the o...